### PR TITLE
NFWWS-5566 Consistent handling of optional fields in document ids

### DIFF
--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/id/DocIdHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/id/DocIdHolder.kt
@@ -23,7 +23,7 @@ class DocIdHolder(docId: DocId, val customSegmentSource: MutableList<DocIdSegmen
         }
     }
 
-    val pattern = docId.value
+    val pattern = docId.value.replace(":null:", "::").replace(":null",":")
 
     init {
         recompile()

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/id/DocIdHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/id/DocIdHolder.kt
@@ -23,7 +23,7 @@ class DocIdHolder(docId: DocId, val customSegmentSource: MutableList<DocIdSegmen
         }
     }
 
-    val pattern = docId.value.replace(":null:", "::").replace(":null",":")
+    val pattern = docId.value.replace(":null:", "::").replace(":null", ":")
 
     init {
         recompile()


### PR DESCRIPTION
If DocId is built by part1:part2:part3 a null part2 would create a DocId with :null:
DocId shall have in this cases ::
An empty PREFIX still possible, but would create unusable doc anyway

Watch-out when mergin! 
Changing DocIds can cause documents not to be found any more.