### PR TITLE
Feature/add super interfaces to interface

### DIFF
--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CommonInterfaceGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CommonInterfaceGeneration.kt
@@ -16,13 +16,13 @@ class CommonInterfaceGeneration {
 
         holder.deprecated?.addDeprecated(interfaceSpec)
 
-        holder.collectAllChildInterfaces().forEach { interfaceSpec.addSuperinterface(it) }
+        holder.collectAllSuperInterfaceNames().forEach { interfaceSpec.addSuperinterface(it) }
 
         val companionSpec = TypeSpec.companionObjectBuilder()
 
         for (fieldHolder in holder.allFields) {
-            val isBaseField = holder.basedOn.any {
-                it.fields.containsKey(fieldHolder.dbField) || it.fieldConstants.containsKey(fieldHolder.dbField)
+            val isBaseField = holder.collectAllSuperInterfaceFields().any {
+                it.hasFieldWithName(fieldHolder.dbField) || it.hasFieldConstantWithName(fieldHolder.dbField)
             }
             val propertySpec = fieldHolder.interfaceProperty(isBaseField, holder.deprecated)
             interfaceSpec.addProperty(propertySpec)
@@ -45,7 +45,7 @@ class CommonInterfaceGeneration {
             .addSuperinterface(TypeUtil.mapSupport())
             .addModifiers(KModifier.PRIVATE)
             .addSuperinterface(holder.interfaceTypeName)
-            .addSuperinterfaces(holder.collectAllChildInterfaces())
+            .addSuperinterfaces(holder.collectAllSuperInterfaceNames())
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, true))
             .addFunction(CblConstantGeneration.addConstants(holder, true))
             .addFunction(SetAllMethodGeneration().generate(holder, false))
@@ -56,7 +56,7 @@ class CommonInterfaceGeneration {
                 ).mutable().initializer("%T()", TypeUtil.linkedHashMapStringAnyNullable()).build()
             )
             .addFunction(constructorMap())
-            .superclass(holder.sourceElement!!.typeName)
+            .superclass(holder.sourceElement.typeName)
 
         holder.deprecated?.addDeprecated(typeBuilder)
 

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CommonInterfaceGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CommonInterfaceGeneration.kt
@@ -45,7 +45,6 @@ class CommonInterfaceGeneration {
             .addSuperinterface(TypeUtil.mapSupport())
             .addModifiers(KModifier.PRIVATE)
             .addSuperinterface(holder.interfaceTypeName)
-            .addSuperinterfaces(holder.collectAllSuperInterfaceNames())
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, true))
             .addFunction(CblConstantGeneration.addConstants(holder, true))
             .addFunction(SetAllMethodGeneration().generate(holder, false))

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CommonInterfaceGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CommonInterfaceGeneration.kt
@@ -16,7 +16,7 @@ class CommonInterfaceGeneration {
 
         holder.deprecated?.addDeprecated(interfaceSpec)
 
-        holder.basedOn.forEach { interfaceSpec.addSuperinterface(it.interfaceTypeName) }
+        holder.collectAllChildInterfaces().forEach { interfaceSpec.addSuperinterface(it) }
 
         val companionSpec = TypeSpec.companionObjectBuilder()
 

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CommonInterfaceGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CommonInterfaceGeneration.kt
@@ -45,6 +45,7 @@ class CommonInterfaceGeneration {
             .addSuperinterface(TypeUtil.mapSupport())
             .addModifiers(KModifier.PRIVATE)
             .addSuperinterface(holder.interfaceTypeName)
+            .addSuperinterfaces(holder.collectAllChildInterfaces())
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, true))
             .addFunction(CblConstantGeneration.addConstants(holder, true))
             .addFunction(SetAllMethodGeneration().generate(holder, false))

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EntityGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EntityGeneration.kt
@@ -59,7 +59,7 @@ class EntityGeneration {
             .addModifiers(KModifier.PUBLIC)
             .addSuperinterface(TypeUtil.iEntity())
             .addSuperinterface(holder.interfaceTypeName)
-            .addSuperinterfaces(holder.collectAllChildInterfaces())
+            .addSuperinterfaces(holder.collectAllSuperInterfaceNames())
             .addProperty(holder.dbNameProperty())
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, false))
             .addFunction(CblDefaultGeneration.addDefaults(holder, false))

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EntityGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EntityGeneration.kt
@@ -59,7 +59,6 @@ class EntityGeneration {
             .addModifiers(KModifier.PUBLIC)
             .addSuperinterface(TypeUtil.iEntity())
             .addSuperinterface(holder.interfaceTypeName)
-            .addSuperinterfaces(holder.collectAllSuperInterfaceNames())
             .addProperty(holder.dbNameProperty())
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, false))
             .addFunction(CblDefaultGeneration.addDefaults(holder, false))

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/WrapperGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/WrapperGeneration.kt
@@ -19,7 +19,6 @@ class WrapperGeneration {
             .addSuperinterface(TypeUtil.mapSupport())
             .addModifiers(KModifier.PUBLIC)
             .addSuperinterface(holder.interfaceTypeName)
-            .addSuperinterfaces(holder.collectAllSuperInterfaceNames())
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, true))
             .addFunction(CblDefaultGeneration.addDefaults(holder, true))
             .addFunction(CblConstantGeneration.addConstants(holder, true))

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/WrapperGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/WrapperGeneration.kt
@@ -19,7 +19,7 @@ class WrapperGeneration {
             .addSuperinterface(TypeUtil.mapSupport())
             .addModifiers(KModifier.PUBLIC)
             .addSuperinterface(holder.interfaceTypeName)
-            .addSuperinterfaces(holder.collectAllChildInterfaces())
+            .addSuperinterfaces(holder.collectAllSuperInterfaceNames())
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, true))
             .addFunction(CblDefaultGeneration.addDefaults(holder, true))
             .addFunction(CblConstantGeneration.addConstants(holder, true))
@@ -28,7 +28,7 @@ class WrapperGeneration {
             .addProperty(PropertySpec.builder("mDoc", TypeUtil.mutableMapStringAnyNullable()).addModifiers(KModifier.PRIVATE).mutable().initializer("%T()", TypeUtil.linkedHashMapStringAnyNullable()).build())
             .addFunction(constructorMap())
             .addFunction(constructorDefault())
-            .superclass(holder.sourceElement!!.typeName)
+            .superclass(holder.sourceElement.typeName)
             .addFunction(BuilderClassGeneration.generateBuilderFun())
 
         holder.deprecated?.addDeprecated(typeBuilder)

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/entity/BaseEntityHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/entity/BaseEntityHolder.kt
@@ -12,7 +12,7 @@ import com.schwarz.crystalprocessor.model.source.ISourceModel
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeName
 
-abstract class BaseEntityHolder(val sourceElement: ISourceModel) : IClassModel by sourceElement {
+abstract class BaseEntityHolder(val sourceElement: ISourceModel) : IClassModel by sourceElement, ModelHolderWithFields {
 
     val fields: MutableMap<String, CblFieldHolder> = mutableMapOf()
 
@@ -56,9 +56,18 @@ abstract class BaseEntityHolder(val sourceElement: ISourceModel) : IClassModel b
     val interfaceTypeName: TypeName
         get() = ClassName(sourcePackage, interfaceSimpleName)
 
-    fun collectAllChildInterfaces(): List<TypeName> {
+    override fun hasFieldWithName(name: String): Boolean = fields.containsKey(name)
+    override fun hasFieldConstantWithName(name: String): Boolean = fieldConstants.containsKey(name)
+
+    fun collectAllSuperInterfaceNames(): List<TypeName> {
         val basedOnInterfaceTypeNames = basedOn.map { it.interfaceTypeName }
         val reducesModelsInterfaceTypeNames = reducesModels.map { ClassName(sourcePackage, "I${it.namePrefix}$sourceClazzSimpleName") }
         return listOf(*basedOnInterfaceTypeNames.toTypedArray(), *reducesModelsInterfaceTypeNames.toTypedArray())
+    }
+
+    fun collectAllSuperInterfaceFields(): List<ModelHolderWithFields> {
+        val basedOnInterfaceTypes = basedOn
+        val reducesModelsInterfaceTypes = reducesModels
+        return listOf(*basedOnInterfaceTypes.toTypedArray(), *reducesModelsInterfaceTypes.toTypedArray())
     }
 }

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/entity/ModelHolderWithFields.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/entity/ModelHolderWithFields.kt
@@ -1,0 +1,6 @@
+package com.schwarz.crystalprocessor.model.entity
+
+interface ModelHolderWithFields {
+    fun hasFieldWithName(name: String): Boolean
+    fun hasFieldConstantWithName(name: String): Boolean
+}

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/entity/ReducedModelHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/entity/ReducedModelHolder.kt
@@ -8,7 +8,7 @@ data class ReducedModelHolder(
     val includeDocId: Boolean,
     val includeBasedOn: Boolean,
     private val parentModel: BaseEntityHolder
-): ModelHolderWithFields {
+) : ModelHolderWithFields {
     override fun hasFieldWithName(name: String): Boolean = includedElements.contains(name)
     override fun hasFieldConstantWithName(name: String): Boolean = includedElements.contains(name)
 }

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/entity/ReducedModelHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/entity/ReducedModelHolder.kt
@@ -8,4 +8,7 @@ data class ReducedModelHolder(
     val includeDocId: Boolean,
     val includeBasedOn: Boolean,
     private val parentModel: BaseEntityHolder
-)
+): ModelHolderWithFields {
+    override fun hasFieldWithName(name: String): Boolean = includedElements.contains(name)
+    override fun hasFieldConstantWithName(name: String): Boolean = includedElements.contains(name)
+}


### PR DESCRIPTION
ticket 10317

I don't need the various "reduced" interfaces to inherit from each other but I need the main interface to inherit from the reduced interfaces. (sorry, I had not thought that far previously)

I then removed the code to let the wrapper and entity classes inherit directly from the reduced-interfaces because they now inherit them indirectly from the main interface anyway.

I think, a very critical eye is well warranted :-)