### PR TITLE
Fix accessor generation for suspend methods

### DIFF
--- a/crystal-map-api/src/main/java/com/schwarz/crystalapi/GenerateAccessor.java
+++ b/crystal-map-api/src/main/java/com/schwarz/crystalapi/GenerateAccessor.java
@@ -11,7 +11,4 @@ import java.lang.annotation.Target;
 public @interface GenerateAccessor {
 
     Class<?> value() default Void.class;
-
-    // We need to explicitly specify this since the information is lost during annotation processing
-    boolean isNullableSuspendFun() default false;
 }

--- a/crystal-map-api/src/main/java/com/schwarz/crystalapi/util/CrystalWrap.kt
+++ b/crystal-map-api/src/main/java/com/schwarz/crystalapi/util/CrystalWrap.kt
@@ -69,7 +69,7 @@ object CrystalWrap {
         fieldName: String
     ): List<T>? = (changes[fieldName] ?: doc[fieldName])?.let { value ->
         catchTypeConversionError(fieldName, value) {
-            value as List<T>
+            (value as List<Any>).map { it as T }
         }
     }
 

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/CodeGenerator.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/CodeGenerator.kt
@@ -76,7 +76,7 @@ class CodeGenerator(private val filer: Filer) {
                 StandardLocation.SOURCE_OUTPUT,
                 fileWithHeader.packageName,
                 "${fileWithHeader.name}.kt",
-                *originatingElements.toTypedArray(),
+                *originatingElements.toTypedArray()
             )
             try {
                 filerSourceFile.openWriter().use { it.write(fixedFileString) }

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/CodeGenerator.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/CodeGenerator.kt
@@ -2,14 +2,21 @@ package com.schwarz.crystalprocessor.generation
 
 import com.schwarz.crystalprocessor.CoachBaseBinderProcessor
 import com.schwarz.crystalprocessor.ProcessingContext
+import com.schwarz.crystalprocessor.model.accessor.CblGenerateAccessorHolder
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.OriginatingElementsHolder
 import java.io.File
 
 import java.io.IOException
 
 import javax.annotation.processing.Filer
 import javax.annotation.processing.ProcessingEnvironment
+import javax.tools.StandardLocation
+import kotlin.io.path.createDirectories
+import kotlin.io.path.isDirectory
+import kotlin.io.path.notExists
+import kotlin.io.path.outputStream
 
 class CodeGenerator(private val filer: Filer) {
 
@@ -27,6 +34,59 @@ class CodeGenerator(private val filer: Filer) {
             fileWithHeader.writeTo(File(codePath))
         } else {
             fileWithHeader.writeTo(filer)
+        }
+    }
+
+    @Throws(IOException::class)
+    fun generateAndFixAccessors(
+        entityToGenerate: FileSpec,
+        generateAccessors: MutableList<CblGenerateAccessorHolder>,
+        processingEnvironment: ProcessingEnvironment
+    ) {
+        ClassName(entityToGenerate.packageName, entityToGenerate.name)?.apply {
+            ProcessingContext.createdQualifiedClazzNames.add(this)
+        }
+
+        val codePath = processingEnvironment.options[CoachBaseBinderProcessor.KAPT_KOTLIN_GENERATED_OPTION_NAME]
+        val fileWithHeader = entityToGenerate.toBuilder().addFileComment(HEADER).build()
+
+        val fixedFileString = generateAccessors.fold(fileWithHeader.toString()) { acc, generateAccessor ->
+            if (generateAccessor.memberFunction != null && generateAccessor.memberFunction.isSuspend) {
+                acc.replace(Regex("(${generateAccessor.memberFunction.name}\\([^)]*\\)):\\s*Unit(\\s*=)"), "$1$2")
+            } else {
+                acc
+            }
+        }
+
+        // used for kapt returns null for legacy annotationprocessor declarations
+        if (codePath != null) {
+            val directory = File(codePath).toPath()
+            require(directory.notExists() || directory.isDirectory()) {
+                "path $directory exists but is not a directory."
+            }
+            val outputPath = directory.resolve(fileWithHeader.relativePath)
+            outputPath.parent.createDirectories()
+            outputPath.outputStream().bufferedWriter().use { it.write(fixedFileString) }
+        } else {
+            val originatingElements = fileWithHeader.members.asSequence()
+                .filterIsInstance<OriginatingElementsHolder>()
+                .flatMap { it.originatingElements.asSequence() }
+                .toSet()
+            val filerSourceFile = filer.createResource(
+                StandardLocation.SOURCE_OUTPUT,
+                fileWithHeader.packageName,
+                "${fileWithHeader.name}.kt",
+                *originatingElements.toTypedArray(),
+            )
+            try {
+                filerSourceFile.openWriter().use { it.write(fixedFileString) }
+            } catch (e: Exception) {
+                try {
+                    filerSourceFile.delete()
+                } catch (ignored: Exception) {
+                }
+                throw e
+            }
         }
     }
 

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/accessor/CblGenerateAccessorHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/accessor/CblGenerateAccessorHolder.kt
@@ -9,8 +9,8 @@ import com.squareup.kotlinpoet.TypeName
 
 class CblGenerateAccessorHolder(
     private val sourceClassTypeName: TypeName,
-    private val memberFunction: SourceMemberFunction?,
-    private val memberProperty: SourceMemberField?
+    val memberFunction: SourceMemberFunction?,
+    val memberProperty: SourceMemberField?
 ) {
 
     fun accessorFunSpec(): FunSpec? {
@@ -32,11 +32,11 @@ class CblGenerateAccessorHolder(
                 memberFunction.name
             )
 
-            val isNullableSuspendFun = memberFunction.generateAccessor?.isNullableSuspendFun ?: false
-
-            if (isNullableSuspendFun) {
-                methodBuilder.returns(memberFunction.returnTypeName.copy(nullable = true))
-            } else {
+            // We only specify a return value if the function is non-suspending. If the function
+            // is suspending, we cannot safely obtain the return type. Since KotlinPoet doesn't
+            // allow us to use implicit return types, we default to Unit and remove it later
+            // in the CodeGenerator.
+            if (!memberFunction.isSuspend) {
                 methodBuilder.returns(memberFunction.returnTypeName)
             }
 

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/source/SourceModel.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/source/SourceModel.kt
@@ -20,7 +20,6 @@ import com.schwarz.crystalapi.Reduces
 import com.schwarz.crystalapi.deprecated.Deprecated
 import com.schwarz.crystalapi.query.Queries
 import com.schwarz.crystalapi.query.Query
-import com.sun.tools.javac.code.Type
 import org.apache.commons.lang3.text.WordUtils
 import org.jetbrains.annotations.Nullable
 import javax.lang.model.element.Element

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/source/SourceModel.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/source/SourceModel.kt
@@ -111,14 +111,7 @@ data class SourceModel(private val sourceElement: Element) : ISourceModel, IClas
                                 }
                             }
 
-                            val returnType = if (isSuspend) {
-                                val continuationParam = (it.parameters.last()) as Symbol.VarSymbol
-                                val continuationParamType = continuationParam.type as Type.ClassType
-                                val wildcardTypeParam = continuationParamType.allparams().first() as Type.WildcardType
-                                wildcardTypeParam.type.asTypeName().javaToKotlinType()
-                            } else {
-                                it.returnType.asTypeName().javaToKotlinType().copy(it.getAnnotation(Nullable::class.java) != null)
-                            }
+                            val returnType = it.returnType.asTypeName().javaToKotlinType().copy(it.getAnnotation(Nullable::class.java) != null)
 
                             relevantStaticsFunctions.add(
                                 SourceMemberFunction(

--- a/demo/src/main/java/com/schwarz/crystaldemo/tesst/Task.kt
+++ b/demo/src/main/java/com/schwarz/crystaldemo/tesst/Task.kt
@@ -36,14 +36,30 @@ open class Task {
         }
 
         @GenerateAccessor
+        fun ultraComplexQueryReturningEntity(storeId: String): List<TaskEntity> {
+            return emptyList()
+        }
+
+        @GenerateAccessor
         suspend fun suspendingUltraComplexQueryReturningList(storeId: String): List<String> {
             return listOf("")
         }
 
-        @GenerateAccessor(isNullableSuspendFun = true)
+        @GenerateAccessor()
         suspend fun suspendingUltraComplexQueryReturningNullableList(storeId: String): List<String>? {
             return null
         }
+
+        @GenerateAccessor()
+        suspend fun suspendingUltraComplexQueryReturningEntity(storeId: String): List<TaskEntity> {
+            return emptyList()
+        }
+
+        @GenerateAccessor()
+        suspend fun suspendingUltraComplexQueryWithAVeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryLongName(storeId: String): List<TaskEntity> {
+            return emptyList()
+        }
+
     }
 //
 //    override fun documentId(): String {

--- a/demo/src/main/java/com/schwarz/crystaldemo/tesst/Task.kt
+++ b/demo/src/main/java/com/schwarz/crystaldemo/tesst/Task.kt
@@ -59,7 +59,6 @@ open class Task {
         suspend fun suspendingUltraComplexQueryWithAVeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryLongName(storeId: String): List<TaskEntity> {
             return emptyList()
         }
-
     }
 //
 //    override fun documentId(): String {


### PR DESCRIPTION
Since accessor methods require a return type in new kotlinpoet versions and we cannot obtain this information from an annotated suspend function, we manually remove the return type from the generated method after generation of the source file.