### PR TITLE
Fix defaults and ensureTypes generation

### DIFF
--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CblDefaultGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/CblDefaultGeneration.kt
@@ -1,15 +1,17 @@
 package com.schwarz.crystalprocessor.generation.model
 
 import com.schwarz.crystalprocessor.model.entity.BaseEntityHolder
+import com.schwarz.crystalprocessor.model.typeconverter.TypeConverterHolderForEntityGeneration
 import com.schwarz.crystalprocessor.util.ConversionUtil
 import com.schwarz.crystalprocessor.util.TypeUtil
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeName
 
 object CblDefaultGeneration {
 
-    fun addDefaults(holder: BaseEntityHolder, useNullableMap: Boolean): FunSpec {
+    fun addDefaults(holder: BaseEntityHolder, useNullableMap: Boolean, typeConvertersByConvertedClass: Map<TypeName, TypeConverterHolderForEntityGeneration>): FunSpec {
         val type =
             if (useNullableMap) TypeUtil.mutableMapStringAnyNullable() else TypeUtil.mutableMapStringAny()
         val valueType =
@@ -19,23 +21,35 @@ object CblDefaultGeneration {
             if (useNullableMap) TypeUtil.anyNullable() else TypeUtil.any()
 
         val builder =
-            FunSpec.builder("addDefaults").addModifiers(KModifier.PRIVATE)
+            FunSpec.builder("addDefaults").addModifiers(KModifier.PRIVATE).addParameter("map", type)
+
+        builder.addStatement("val result = mutableMapOf<String, Any?>()")
 
         for (fieldHolder in holder.fields.values) {
             if (fieldHolder.isDefault) {
-                builder.addStatement(
-                    "this.%N = ${ConversionUtil.convertStringToDesiredFormat(
+                fieldHolder.crystalWrapSetStatement(
+                    builder,
+                    "result",
+                    typeConvertersByConvertedClass,
+                    ConversionUtil.convertStringToDesiredFormat(
                         fieldHolder.typeMirror,
                         fieldHolder.defaultValue
-                    )}",
-                    fieldHolder.accessorSuffix()
+                    )
                 )
             }
         }
+
+        builder.addCode(
+            CodeBlock.builder()
+                .beginControlFlow("result.forEach")
+                .beginControlFlow("if(it.value != null)").addStatement("map[it.key] = it.value!!").endControlFlow()
+                .endControlFlow()
+                .build()
+        )
         return builder.build()
     }
 
-    fun addAddCall(): CodeBlock {
-        return CodeBlock.builder().addStatement("addDefaults()").build()
+    fun addAddCall(nameOfMap: String): CodeBlock {
+        return CodeBlock.builder().addStatement("addDefaults(%N)", nameOfMap).build()
     }
 }

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EnsureTypesGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EnsureTypesGeneration.kt
@@ -19,55 +19,17 @@ object EnsureTypesGeneration {
         val explicitType =
             if (useNullableMap) TypeUtil.hashMapStringAnyNullable() else TypeUtil.hashMapStringAny()
         val type = if (useNullableMap) TypeUtil.mapStringAnyNullable() else TypeUtil.mapStringAny()
-        val typeConversionReturnType =
-            if (useNullableMap) TypeUtil.anyNullable() else TypeUtil.any()
         val ensureTypes = FunSpec.builder("ensureTypes").addParameter("doc", type).returns(type)
         ensureTypes.addStatement("val %N = %T()", RESULT_VAL_NAME, explicitType)
         ensureTypes.addStatement("%N.putAll(doc)", RESULT_VAL_NAME)
 
         for (field in holder.fields.values) {
-            if (field.isNonConvertibleClass) {
-                if (field.isIterable) {
-                    ensureTypes.addStatement(
-                        "%T.getList<%T>(mutableMapOf(), %N, %N)",
-                        CrystalWrap::class,
-                        field.fieldType,
-                        RESULT_VAL_NAME,
-                        field.constantName
-                    )
-                } else {
-                    ensureTypes.addStatement(
-                        "%T.get<%T>(mutableMapOf(), %N, %N)",
-                        CrystalWrap::class,
-                        field.fieldType,
-                        RESULT_VAL_NAME,
-                        field.constantName
-                    )
-                }
-            } else if (field.isTypeOfSubEntity) {
-                if (field.isIterable) {
-                    ensureTypes.addStatement(
-                        "%T.getList(mutableMapOf(), %N, %N, {%T.fromMap(it) ?: emptyList()})",
-                        CrystalWrap::class,
-                        RESULT_VAL_NAME,
-                        field.constantName,
-                        field.subEntityTypeName
-                    )
-                } else {
-                    ensureTypes.addStatement(
-                        "%T.get(mutableMapOf(), %N, %N, {%T.fromMap(it)})",
-                        CrystalWrap::class,
-                        RESULT_VAL_NAME,
-                        field.constantName,
-                        field.subEntityTypeName
-                    )
-                }
-            } else {
+            if (!field.isNonConvertibleClass && !field.isTypeOfSubEntity) {
                 val typeConverterHolder =
                     typeConvertersByConvertedClass.get(field.fieldType)!!
                 if (field.isIterable) {
                     ensureTypes.addStatement(
-                        "%T.getList(mutableMapOf(), %N, %N, %T)",
+                        "%T.ensureListType(%N, %N, %T)",
                         CrystalWrap::class,
                         RESULT_VAL_NAME,
                         field.constantName,
@@ -75,7 +37,7 @@ object EnsureTypesGeneration {
                     )
                 } else {
                     ensureTypes.addStatement(
-                        "%T.get(mutableMapOf(), %N, %N, %T)",
+                        "%T.ensureType(%N, %N, %T)",
                         CrystalWrap::class,
                         RESULT_VAL_NAME,
                         field.constantName,

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EntityGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EntityGeneration.kt
@@ -69,7 +69,7 @@ class EntityGeneration {
             .addSuperinterface(MandatoryCheck::class)
             .addProperty(holder.dbNameProperty())
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, false, typeConvertersByConvertedClass))
-            .addFunction(CblDefaultGeneration.addDefaults(holder, false))
+            .addFunction(CblDefaultGeneration.addDefaults(holder, false, typeConvertersByConvertedClass))
             .addFunction(CblConstantGeneration.addConstants(holder, false))
             .addFunction(ValidateMethodGeneration.generate(holder, true))
             .addProperty(

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/RebindMethodGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/RebindMethodGeneration.kt
@@ -11,7 +11,7 @@ class RebindMethodGeneration {
         val type = if (clearMDocChanges) TypeUtil.mapStringAny() else TypeUtil.mapStringAnyNullable()
         val rebind = FunSpec.builder("rebind").addParameter("doc", type)
             .addStatement("mDoc = %T()", explicitType)
-            .addCode(CblDefaultGeneration.addAddCall())
+            .addCode(CblDefaultGeneration.addAddCall("mDoc"))
             .addCode(
                 CodeBlock.builder()
                     .beginControlFlow("if(doc != null)")

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/WrapperGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/WrapperGeneration.kt
@@ -23,7 +23,7 @@ class WrapperGeneration {
             .addSuperinterface(holder.interfaceTypeName)
             .addSuperinterface(MandatoryCheck::class)
             .addFunction(EnsureTypesGeneration.ensureTypes(holder, true, typeConvertersByConvertedClass))
-            .addFunction(CblDefaultGeneration.addDefaults(holder, true))
+            .addFunction(CblDefaultGeneration.addDefaults(holder, true, typeConvertersByConvertedClass))
             .addFunction(CblConstantGeneration.addConstants(holder, true))
             .addFunction(SetAllMethodGeneration().generate(holder, false))
             .addFunction(MapSupportGeneration.toMap(holder))

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/field/CblFieldHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/field/CblFieldHolder.kt
@@ -90,7 +90,21 @@ class CblFieldHolder(field: Field, classPaths: List<String>, subEntityNameSuffix
 
         deprecated?.addDeprecated(dbField, propertyBuilder)
 
-        val mDocPhrase = if (useMDocChanges) "mDocChanges, mDoc" else "mDoc, mutableMapOf()"
+        crystalWrapGetStatement(getter, if (useMDocChanges) "mDocChanges, mDoc" else "mDoc, mutableMapOf()", typeConvertersByConvertedClass)
+        crystalWrapSetStatement(setter, if (useMDocChanges) "mDocChanges" else "mDoc", typeConvertersByConvertedClass, "value")
+
+        if (comment.isNotEmpty()) {
+            propertyBuilder.addKdoc(KDocGeneration.generate(comment))
+        }
+
+        return propertyBuilder.setter(setter.build()).getter(getter.build()).build()
+    }
+
+    fun crystalWrapGetStatement(
+        getter: FunSpec.Builder,
+        mDocPhrase: String,
+        typeConvertersByConvertedClass: Map<TypeName, TypeConverterHolderForEntityGeneration>
+    ) {
         if (isNonConvertibleClass) {
             if (isIterable) {
                 getter.addStatement(
@@ -156,14 +170,6 @@ class CblFieldHolder(field: Field, classPaths: List<String>, subEntityNameSuffix
                 )
             }
         }
-
-        crystalWrapSetStatement(setter, if (useMDocChanges) "mDocChanges" else "mDoc", typeConvertersByConvertedClass, "value")
-
-        if (comment.isNotEmpty()) {
-            propertyBuilder.addKdoc(KDocGeneration.generate(comment))
-        }
-
-        return propertyBuilder.setter(setter.build()).getter(getter.build()).build()
     }
 
     fun crystalWrapSetStatement(

--- a/demo/src/main/java/com/schwarz/crystaldemo/customtypes/LocalDateConverter.kt
+++ b/demo/src/main/java/com/schwarz/crystaldemo/customtypes/LocalDateConverter.kt
@@ -1,0 +1,13 @@
+package com.schwarz.crystaldemo.customtypes
+
+import com.schwarz.crystalapi.ITypeConverter
+import com.schwarz.crystalapi.TypeConverter
+import java.time.LocalDate
+
+@TypeConverter
+abstract class LocalDateConverter : ITypeConverter<LocalDate, String> {
+    override fun write(value: LocalDate?): String? =
+        value?.toString()
+
+    override fun read(value: String?): LocalDate? = value?.let { LocalDate.parse(it) }
+}

--- a/demo/src/main/java/com/schwarz/crystaldemo/entity/Product.kt
+++ b/demo/src/main/java/com/schwarz/crystaldemo/entity/Product.kt
@@ -8,12 +8,12 @@ import com.schwarz.crystalapi.Entity
 import com.schwarz.crystalapi.Field
 import com.schwarz.crystalapi.Fields
 import com.schwarz.crystalapi.MapWrapper
-import com.schwarz.crystalapi.SchemaClass
 import com.schwarz.crystalapi.Reduce
 import com.schwarz.crystalapi.Reduces
+import com.schwarz.crystalapi.SchemaClass
 import com.schwarz.crystalapi.query.Queries
 import com.schwarz.crystalapi.query.Query
-import java.util.Date
+import java.time.LocalDate
 
 @Entity(database = "mydb_db")
 @MapWrapper
@@ -39,10 +39,16 @@ import java.util.Date
         list = true,
         comment = ["I'm also comfortable with pseudo %2D placeholders"]
     ),
+    Field(
+        name = "top_comment",
+        type = UserComment::class
+    ),
     Field(name = "image", type = Blob::class),
     Field(name = "identifiers", type = String::class, list = true),
     Field(name = "category", type = ProductCategory::class),
-    Field(name = "some_date", type = Date::class)
+    Field(name = "some_date", type = LocalDate::class),
+    Field(name = "some_dates", type = LocalDate::class, list = true),
+    Field(name = "field_with_default", type = String::class, defaultValue = "foobar")
 )
 @Queries(
     Query(fields = ["type"]),

--- a/demo/src/test/java/kaufland/com/demo/entity/ProductEntityTest.kt
+++ b/demo/src/test/java/kaufland/com/demo/entity/ProductEntityTest.kt
@@ -4,30 +4,28 @@ import com.schwarz.crystalapi.PersistenceConfig
 import com.schwarz.crystalapi.TypeConversionErrorWrapper
 import com.schwarz.crystaldemo.UnitTestConnector
 import com.schwarz.crystaldemo.entity.ProductCategory.AMAZING_PRODUCT
-import com.schwarz.crystaldemo.logger.TestAppender
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import org.mockito.internal.matchers.Null
-import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import kotlin.system.measureTimeMillis
 
-private val logger =
-    LoggerFactory.getLogger(ProductEntityTestConnector::class.java) as ch.qos.logback.classic.Logger
+object LastErrorWrapper {
+    var value: TypeConversionErrorWrapper? = null
 
-private val dataTypeErrorMsg: (String?, String?, String?) -> String
-    get() = { fieldName, value, `class` ->
-        "Field $fieldName manipulated: Tried to cast $value into $`class`"
+    fun clear() {
+        value = null
     }
+}
+
+object ErrorProducingObject
 
 object ProductEntityTestConnector : UnitTestConnector() {
-    init {
-        TestAppender().run {
-            name = this::class.java.simpleName
-            logger.addAppender(this)
-            start()
-        }
-    }
 
     override fun queryDoc(
         dbName: String,
@@ -39,19 +37,7 @@ object ProductEntityTestConnector : UnitTestConnector() {
     }
 
     override fun invokeOnError(errorWrapper: TypeConversionErrorWrapper) {
-        if (errorWrapper.exception is ClassCastException) {
-            logger.error(
-                dataTypeErrorMsg.invoke(
-                    errorWrapper.fieldName,
-                    if (errorWrapper.value != null) {
-                        errorWrapper.value?.javaClass?.kotlin?.simpleName ?: ""
-                    } else {
-                        Null.NULL.toString().lowercase()
-                    },
-                    errorWrapper.`class`.simpleName
-                )
-            )
-        }
+        LastErrorWrapper.value = errorWrapper
     }
 }
 
@@ -65,6 +51,11 @@ class ProductEntityTest {
         }
     }
 
+    @Before
+    fun before() {
+        LastErrorWrapper.clear()
+    }
+
     @Test
     fun `findByTypeAndCategory should use the expected query-params`() {
         val category = AMAZING_PRODUCT
@@ -75,66 +66,415 @@ class ProductEntityTest {
         assertEquals(ProductEntity.DOC_TYPE, queryParams.type)
     }
 
-    /**
-     * Can happen if combined db data is changed wilfully.
-     */
     @Test
-    fun `data type changed at runtime test suppress exception`() {
+    fun `entity with an invalid type for fields without type conversions should produce error on get`() {
         val map: MutableMap<String, Any> = mutableMapOf(
             "name" to 1
         )
-        ProductEntity.create(map)
-        assertEquals(
-            (logger.getAppender(TestAppender::class.java.simpleName) as TestAppender).lastLoggedEvent?.message,
-            dataTypeErrorMsg.invoke("name", 1::class.simpleName, String::class.simpleName)
-        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+        assertThrows(Exception::class.java) { entity.name }
     }
 
-    /**
-     * Can happen if combined db data is changed wilfully.
-     */
     @Test
-    fun `list data type changed at runtime test suppress exception`() {
+    fun `entity with an invalid type for list fields without type conversions should produce error on get`() {
         val map: MutableMap<String, Any> = mutableMapOf(
             "identifiers" to 1
         )
-        ProductEntity.create(map)
-        assertEquals(
-            (logger.getAppender(TestAppender::class.java.simpleName) as TestAppender).lastLoggedEvent?.message,
-            dataTypeErrorMsg.invoke("identifiers", 1::class.simpleName, List::class.simpleName)
-        )
+
+        val entity = ProductEntity.create(map)
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.identifiers
+
+        assertNull(result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("identifiers", errorWrapper?.fieldName)
+        assertEquals(1, errorWrapper?.value)
+        assertEquals(List::class, errorWrapper?.`class`)
     }
 
-    /**
-     * Can happen if combined db data is changed wilfully.
-     */
     @Test
-    fun `list item data type changed at runtime test suppress exception`() {
+    fun `entity with an invalid list type for list fields without type conversions should produce error on get`() {
         val map: MutableMap<String, Any> = mutableMapOf(
             "identifiers" to listOf(1)
         )
-        ProductEntity.create(map)
-        assertEquals(
-            (logger.getAppender(TestAppender::class.java.simpleName) as TestAppender).lastLoggedEvent?.message,
-            dataTypeErrorMsg.invoke("identifiers", "SingletonList", List::class.simpleName)
-        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.identifiers
+
+        assertEquals(emptyList<String>(), result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("identifiers", errorWrapper?.fieldName)
+        assertEquals(1, errorWrapper?.value)
+        assertEquals(String::class, errorWrapper?.`class`)
     }
 
     @Test
-    fun `data type consistent`() {
+    fun `entity with an invalid type for fields that are subentities produce error on get`() {
         val map: MutableMap<String, Any> = mutableMapOf(
-            "name" to "1"
+            "top_comment" to 1
         )
-        ProductEntity.create(map)
-        assertNull((logger.getAppender(TestAppender::class.java.simpleName) as TestAppender).lastLoggedEvent?.message)
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.topComment
+
+        assertNull(result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("top_comment", errorWrapper?.fieldName)
+        assertEquals(1, errorWrapper?.value)
+        assertEquals(UserCommentWrapper::class, errorWrapper?.`class`)
     }
 
     @Test
-    fun `list data type consistent`() {
+    fun `entity with an invalid list type for fields that are subentities returns emptyList`() {
         val map: MutableMap<String, Any> = mutableMapOf(
-            "identifiers" to listOf("Foo")
+            "comments" to 1
         )
-        ProductEntity.create(map)
-        assertNull((logger.getAppender(TestAppender::class.java.simpleName) as TestAppender).lastLoggedEvent?.message)
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.comments
+
+        assertNull(result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("comments", errorWrapper?.fieldName)
+        assertEquals(1, errorWrapper?.value)
+        assertEquals(List::class, errorWrapper?.`class`)
+    }
+
+    @Test
+    fun `entity with an invalid list type for fields that are subentities throws on get`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "comments" to listOf(1)
+        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.comments
+
+        assertEquals(emptyList<UserCommentWrapper>(), result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("comments", errorWrapper?.fieldName)
+        assertEquals(1, errorWrapper?.value)
+        assertEquals(UserCommentWrapper::class, errorWrapper?.`class`)
+    }
+
+    @Test
+    fun `entity with an invalid type for fields with type conversions should produce error on get`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_date" to true
+        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.someDate
+
+        assertNull(result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("some_date", errorWrapper?.fieldName)
+        assertEquals(true, errorWrapper?.value)
+        assertEquals(LocalDate::class, errorWrapper?.`class`)
+    }
+
+    @Test
+    fun `entity with an invalid list type for fields with type conversions produce error on get`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_dates" to listOf(true)
+        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.someDates
+
+        assertEquals(emptyList<LocalDate>(), result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("some_dates", errorWrapper?.fieldName)
+        assertEquals(true, errorWrapper?.value)
+        assertEquals(LocalDate::class, errorWrapper?.`class`)
+    }
+
+    @Test
+    fun `entity with an invalid value for fields with type conversions should produce error on get`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_date" to "foobar"
+        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.someDate
+
+        assertNull(result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("some_date", errorWrapper?.fieldName)
+        assertEquals("foobar", errorWrapper?.value)
+        assertEquals(LocalDate::class, errorWrapper?.`class`)
+    }
+
+    @Test
+    fun `entity with a list of invalid values for fields with type conversions produce error on get`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_dates" to listOf("foobar")
+        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.someDates
+
+        assertEquals(emptyList<LocalDate>(), result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("some_dates", errorWrapper?.fieldName)
+        assertEquals("foobar", errorWrapper?.value)
+        assertEquals(LocalDate::class, errorWrapper?.`class`)
+    }
+
+    @Test
+    fun `creating an entity with an invalid deserialized type should produce error on get`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_date" to ErrorProducingObject
+        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.someDate
+
+        assertNull(result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("some_date", errorWrapper?.fieldName)
+        assertEquals(ErrorProducingObject, errorWrapper?.value)
+        assertEquals(LocalDate::class, errorWrapper?.`class`)
+    }
+
+    @Test
+    fun `entity with a list of invalid deserialized types produce error on get`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_dates" to listOf(ErrorProducingObject)
+        )
+
+        val entity = ProductEntity.create(map)
+
+        assertNull(LastErrorWrapper.value)
+
+        val result = entity.someDates
+
+        assertEquals(emptyList<LocalDate>(), result)
+        val errorWrapper = LastErrorWrapper.value
+        assertNotNull(errorWrapper)
+        assertEquals("some_dates", errorWrapper?.fieldName)
+        assertEquals(ErrorProducingObject, errorWrapper?.value)
+        assertEquals(LocalDate::class, errorWrapper?.`class`)
+    }
+
+    @Test
+    fun `entity with an valid type for fields without type conversions should return`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "name" to "Fritz"
+        )
+
+        val entity = ProductEntity.create(map)
+
+        assertEquals("Fritz", entity.name)
+        assertNull(LastErrorWrapper.value)
+    }
+
+    @Test
+    fun `entity with an valid type for list fields without type conversions should return`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "identifiers" to listOf("1", "2")
+        )
+
+        val entity = ProductEntity.create(map)
+        assertNull(LastErrorWrapper.value)
+
+        assertEquals(listOf("1", "2"), entity.identifiers)
+        assertNull(LastErrorWrapper.value)
+    }
+
+    @Test
+    fun `entity with an valid type for fields that are subentities should return`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "top_comment" to mapOf("comment" to "foobar")
+        )
+
+        val entity = ProductEntity.create(map)
+        val result = entity.topComment
+
+        assertNotNull(result)
+        assertEquals("foobar", result?.comment)
+        assertNull(LastErrorWrapper.value)
+    }
+
+    @Test
+    fun `entity with an valid list type for fields that are subentities returns`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "comments" to listOf(mapOf("comment" to "foobar"))
+        )
+
+        val entity = ProductEntity.create(map)
+        val result = entity.comments
+
+        assertNotNull(result)
+        assertEquals("foobar", result?.first()?.comment)
+        assertNull(LastErrorWrapper.value)
+    }
+
+    @Test
+    fun `entity with an valid type for fields with type conversions should return`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_date" to "2023-01-01"
+        )
+
+        val entity = ProductEntity.create(map)
+        val result = entity.someDate
+
+        assertNotNull(result)
+        assertEquals(LocalDate.of(2023, 1, 1), result)
+        assertNull(LastErrorWrapper.value)
+    }
+
+    @Test
+    fun `entity with an valid list type for fields with type conversions should return`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_dates" to listOf("2023-01-01")
+        )
+
+        val entity = ProductEntity.create(map)
+        val result = entity.someDates
+
+        assertNotNull(result)
+        assertEquals(LocalDate.of(2023, 1, 1), result?.first())
+        assertNull(LastErrorWrapper.value)
+    }
+
+    @Test
+    fun `entity with an valid deserialized type for fields with type conversions should return`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_date" to LocalDate.of(2023, 1, 1)
+        )
+
+        val entity = ProductEntity.create(map)
+        val result = entity.someDate
+
+        assertNotNull(result)
+        assertEquals(LocalDate.of(2023, 1, 1), result)
+        assertNull(LastErrorWrapper.value)
+    }
+
+    @Test
+    fun `entity with an valid deserialized list type for fields with type conversions should return`() {
+        val map: MutableMap<String, Any> = mutableMapOf(
+            "some_dates" to listOf(LocalDate.of(2023, 1, 1))
+        )
+
+        val entity = ProductEntity.create(map)
+        val result = entity.someDates
+
+        assertNotNull(result)
+        assertEquals(LocalDate.of(2023, 1, 1), result?.first())
+        assertNull(LastErrorWrapper.value)
+    }
+
+    @Test
+    fun `default values and constants should be set`() {
+        val entity = ProductEntity.create()
+
+        assertEquals(entity.type, "product")
+        assertEquals(entity.fieldWithDefault, "foobar")
+        val toMapResult = entity.toMap()
+        assertEquals("product", toMapResult["type"])
+        assertEquals("foobar", toMapResult["field_with_default"])
+    }
+
+    @Test
+    fun `default values should be overwritable through setter`() {
+        val entity = ProductEntity.create()
+
+        entity.fieldWithDefault = "barfoo"
+
+        assertEquals(entity.fieldWithDefault, "barfoo")
+        val toMapResult = entity.toMap()
+        assertEquals("barfoo", toMapResult["field_with_default"])
+    }
+
+    @Test
+    fun `default values should be overwritable from doc`() {
+        val map = mutableMapOf<String, Any>("field_with_default" to "barfoo")
+        val entity = ProductEntity.create(map)
+
+        assertEquals(entity.fieldWithDefault, "barfoo")
+        val toMapResult = entity.toMap()
+        assertEquals("barfoo", toMapResult["field_with_default"])
+    }
+
+    @Test
+    fun `constant values should not be overwritable from doc`() {
+        val map = mutableMapOf<String, Any>("type" to "barfoo")
+        val entity = ProductEntity.create(map)
+
+        assertEquals(entity.type, "product")
+        val toMapResult = entity.toMap()
+        assertEquals("product", toMapResult["type"])
+    }
+
+    @Test
+    fun `additional fields in the map should not impact the entity`() {
+        val map = mutableMapOf<String, Any>("type" to "barfoo", "this_field_is_not_in_the_schema" to "1234")
+        val entity = ProductEntity.create(map)
+
+        assertEquals(entity.type, "product")
+        val toMapResult = entity.toMap()
+        assertEquals("product", toMapResult["type"])
+    }
+
+    @Test
+    fun `creating and reading 1000 docs with 1000 positions should take less than 600ms`() {
+        val positions = List(1000) { mutableMapOf("comment" to "$it") }
+        val someDates = List(1000) { LocalDate.now().toString() }
+        val maps = List(1000) {
+            mutableMapOf<String, Any>(
+                "comments" to positions,
+                "some_dates" to someDates
+            )
+        }
+
+        val duration = measureTimeMillis {
+            val entities = maps.map { ProductEntity.create(it) }
+            entities.flatMap { it.comments ?: emptyList() }
+            entities.flatMap { it.someDates ?: emptyList() }
+        }
+
+        assertTrue("Expecting time for creating and reading to be < 600ms but was $duration", duration < 600)
     }
 }

--- a/demo/src/test/java/kaufland/com/demo/entity/ProductWrapperTest.kt
+++ b/demo/src/test/java/kaufland/com/demo/entity/ProductWrapperTest.kt
@@ -5,7 +5,7 @@ import com.schwarz.crystaldemo.UnitTestConnector
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
 import org.junit.Test
-import java.util.Date
+import java.time.LocalDate
 
 class ProductWrapperTest {
     companion object {
@@ -29,6 +29,7 @@ class ProductWrapperTest {
         map.remove(ProductWrapper.TYPE)
         assertEquals(
             mapOf(
+                ProductWrapper.FIELD_WITH_DEFAULT to "foobar",
                 ProductWrapper.NAME to "name",
                 ProductWrapper.COMMENTS to listOf<UserCommentWrapper>(),
                 ProductWrapper.IDENTIFIERS to listOf("1", "2")
@@ -50,7 +51,7 @@ class ProductWrapperTest {
             )
             .setCategory(ProductCategory.AMAZING_PRODUCT)
             .setIdentifiers(listOf("1", "2"))
-            .setSomeDate(Date())
+            .setSomeDate(LocalDate.now())
             .exit()
         val map = product.toMap() as MutableMap<String, Any?>
 


### PR DESCRIPTION
* Makes sure defaults are handled properly
* reverts some new logic in the ensuretypes function that lead to excessive overhead
* adds proper test coverage for getters and setters
* ensures consistent handling of type conversion errors