### PR TITLE
Use type converters in builDodcId-method

### DIFF
--- a/.github/workflows/android_pre_hook.yml
+++ b/.github/workflows/android_pre_hook.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: gradle
 
     - name: Grant execute permission for gradlew

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EntityGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/EntityGeneration.kt
@@ -95,7 +95,7 @@ class EntityGeneration {
         holder.deprecated?.addDeprecated(typeBuilder)
 
         holder.docId?.let {
-            companionSpec.addFunction(it.companionFunction(holder))
+            companionSpec.addFunction(it.companionFunction(holder, typeConvertersByConvertedClass))
             typeBuilder.addFunction(it.buildExpectedDocId(holder))
             typeBuilder.addSuperinterface(TypeUtil.iDocId())
         }

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/WrapperGeneration.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/generation/model/WrapperGeneration.kt
@@ -37,7 +37,7 @@ class WrapperGeneration {
         holder.deprecated?.addDeprecated(typeBuilder)
 
         holder.docId?.let {
-            companionSpec.addFunction(it.companionFunction(holder))
+            companionSpec.addFunction(it.companionFunction(holder, typeConvertersByConvertedClass))
             typeBuilder.addFunction(it.buildExpectedDocId(holder))
             typeBuilder.addSuperinterface(TypeUtil.iDocId())
         }

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/id/DocIdHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/id/DocIdHolder.kt
@@ -91,11 +91,12 @@ class DocIdHolder(docId: DocId, val customSegmentSource: MutableList<DocIdSegmen
                 })}"
             }
                 ?: entityFields.map { (_, fieldHolder) ->
+                    val accessorSuffix = fieldHolder.accessorSuffix()
                     if (fieldHolder.isNonConvertibleClass) {
-                        fieldHolder.accessorSuffix()
+                        accessorSuffix
                     } else {
                         val typeConverter = typeConvertersByConvertedClass[fieldHolder.fieldType]!!.instanceClassTypeName.simpleName
-                        "{$typeConverter.write(${fieldHolder.accessorSuffix()})}"
+                        "{$typeConverter.write($accessorSuffix)}"
                     }
                 }
                     .joinToString(separator = ",") { "\$$it" }

--- a/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/id/DocIdHolder.kt
+++ b/crystal-map-processor/src/main/java/com/schwarz/crystalprocessor/model/id/DocIdHolder.kt
@@ -5,6 +5,7 @@ import com.schwarz.crystalprocessor.model.field.CblFieldHolder
 import com.schwarz.crystalprocessor.util.TypeUtil
 import com.squareup.kotlinpoet.*
 import com.schwarz.crystalapi.DocId
+import com.schwarz.crystalprocessor.model.typeconverter.TypeConverterHolderForEntityGeneration
 import java.util.regex.Pattern
 
 class DocIdHolder(docId: DocId, val customSegmentSource: MutableList<DocIdSegmentHolder>) {
@@ -76,7 +77,7 @@ class DocIdHolder(docId: DocId, val customSegmentSource: MutableList<DocIdSegmen
         return segments.map { it.fieldsToModelFields(model) }.flatten().map { it.accessorSuffix() }.distinct()
     }
 
-    fun companionFunction(entity: BaseEntityHolder): FunSpec {
+    fun companionFunction(entity: BaseEntityHolder, typeConvertersByConvertedClass: Map<TypeName, TypeConverterHolderForEntityGeneration>): FunSpec {
         val spec = FunSpec.builder(COMPANION_BUILD_FUNCTION_NAME).addAnnotation(JvmStatic::class)
             .returns(TypeUtil.string())
         var statement = pattern
@@ -89,7 +90,14 @@ class DocIdHolder(docId: DocId, val customSegmentSource: MutableList<DocIdSegmen
                 entityFields.map { it.value.accessorSuffix() }.joinToString(separator = ",")
                 })}"
             }
-                ?: entityFields.map { it.value.accessorSuffix() }
+                ?: entityFields.map { (_, fieldHolder) ->
+                    if (fieldHolder.isNonConvertibleClass) {
+                        fieldHolder.accessorSuffix()
+                    } else {
+                        val typeConverter = typeConvertersByConvertedClass[fieldHolder.fieldType]!!.instanceClassTypeName.simpleName
+                        "{$typeConverter.write(${fieldHolder.accessorSuffix()})}"
+                    }
+                }
                     .joinToString(separator = ",") { "\$$it" }
 
             statement = statement.replace("%${segment.segment}%", statementValue)

--- a/crystal-map-processor/src/test/java/com/schwarz/CouchbaseBaseBinderProcessorKotlinTest.kt
+++ b/crystal-map-processor/src/test/java/com/schwarz/CouchbaseBaseBinderProcessorKotlinTest.kt
@@ -124,6 +124,15 @@ class CouchbaseBaseBinderProcessorKotlinTest {
     }
 
     @Test
+    fun testSuccessDocIdEnumGeneration() {
+        val compilation = compileKotlin(
+            TestDataHelper.clazzAsJavaFileObjects("EntityWithEnumDocId"),
+            useSuspend = true
+        )
+        Assert.assertEquals(KotlinCompilation.ExitCode.OK, compilation.exitCode)
+    }
+
+    @Test
     fun testSuccessDocIdSegmentGeneration() {
         val compilation = compileKotlin(
             TestDataHelper.clazzAsJavaFileObjects("EntityWithDocIdAndDocIdSegments"),

--- a/crystal-map-processor/src/test/resources/EntityWithEnumDocId.kt
+++ b/crystal-map-processor/src/test/resources/EntityWithEnumDocId.kt
@@ -1,0 +1,24 @@
+import com.schwarz.crystalapi.*
+import com.schwarz.crystalapi.typeconverters.EnumConverter
+import java.lang.String
+
+enum class TestEnum {
+        TEST_VALUE1,
+        TEST_VALUE2
+}
+
+@TypeConverter
+open class TestEnumConverter: ITypeConverter<TestEnum, kotlin.String> by EnumConverter(TestEnum::class)
+
+@Entity(database = "mydb_db")
+@Fields(
+        Field(name = "name", type = String::class),
+        Field(name = "type", type = String::class, defaultValue = "entityWithQueries", readonly = true),
+        Field(name = "identifiers", type = String::class, list = true),
+        Field(name = "enumField", type = TestEnum::class),
+        Field(name = "map", type = Map::class, list = true)
+)
+@DocId("my:%name%:%type%:%enumField%")
+open class EntityWithEnumDocId {
+
+}


### PR DESCRIPTION
A DocID
`@DocId("prefix:%someString%:%state%")`

Will be mapped to the following buildDocId-method:

```
 public fun buildDocId(someString: String?, state: State?): String =
      """prefix:$someString:${StateConverterInstance.write(state)}"""
```
